### PR TITLE
Add handling for Stock By Attributes

### DIFF
--- a/2_new_files/your_admin_folder/edit_orders.php
+++ b/2_new_files/your_admin_folder/edit_orders.php
@@ -999,6 +999,7 @@
                     case PRODUCTS_OPTIONS_TYPE_ATTRIBUTE_GRID:
                     case PRODUCTS_OPTIONS_TYPE_RADIO:
                     case PRODUCTS_OPTIONS_TYPE_SELECT:
+                    case PRODUCTS_OPTIONS_TYPE_SELECT_SBA:
                         echo '<label class="attribsSelect" for="opid-' .
                             $orders_products_id . '-oid-' . $optionID[$j] .
                             '">' . $optionInfo['name'] . '</label>';

--- a/2_new_files/your_admin_folder/includes/functions/extra_functions/edit_orders_functions.php
+++ b/2_new_files/your_admin_folder/includes/functions/extra_functions/edit_orders_functions.php
@@ -1732,4 +1732,9 @@ function eo_checks_and_warnings() {
             define('PRODUCTS_OPTIONS_TYPE_ATTRIBUTE_GRID', '-1');
         }
     }
+    
+    // Check for the installation of "Potteryhouse's/mc12345678's Stock By Attributes"
+    if(!defined('PRODUCTS_OPTIONS_TYPE_SELECT_SBA')) {
+        define('PRODUCTS_OPTIONS_TYPE_SELECT_SBA', '-1');
+    }
 }


### PR DESCRIPTION
Stock By Attributes includes a new product type that
can be treated similar to the following ZC product types:
PRODUCTS_OPTIONS_TYPE_ATTRIBUTE_GRID
PRODUCTS_OPTIONS_TYPE_RADIO
PRODUCTS_OPTIONS_TYPE_SELECT

The product type is added to the proper tables and
areas as expected and described in the Edit Orders
forum including handling the case where it is not installed.

Fixes Issue #39