### PR TITLE
fixes warnings when POST is empty or non-numeric

### DIFF
--- a/YOUR_ADMIN/includes/classes/editOrders.php
+++ b/YOUR_ADMIN/includes/classes/editOrders.php
@@ -209,7 +209,7 @@ class editOrders extends base
                     $ot_shipping = json_encode($current_total);
                     $found_ot_shipping = true;
                     $shipping_module = $current_total['shipping_module'] . '_';
-                    $shipping_cost = (float)$current_total['value'];
+                    $shipping_cost = floatval($current_total['value']);
                     $shipping_title = $current_total['title'];
                     break;
                 }

--- a/YOUR_ADMIN/includes/classes/editOrders.php
+++ b/YOUR_ADMIN/includes/classes/editOrders.php
@@ -209,7 +209,7 @@ class editOrders extends base
                     $ot_shipping = json_encode($current_total);
                     $found_ot_shipping = true;
                     $shipping_module = $current_total['shipping_module'] . '_';
-                    $shipping_cost = $current_total['value'];
+                    $shipping_cost = (float)$current_total['value'];
                     $shipping_title = $current_total['title'];
                     break;
                 }


### PR DESCRIPTION
take an order with tax where the store charges tax on the shipping cost.  the store admin goes in to edit the order and wants to remove the shipping cost from the order.  if the admin just deletes the shipping cost and leaves it as blank, you will generate warnings for non-numeric calculations when it comes to calculate tax.  this fix addresses that situation.