### PR TITLE
Fix issue raised by Ted Grapler

### DIFF
--- a/YOUR_ADMIN/edit_orders.php
+++ b/YOUR_ADMIN/edit_orders.php
@@ -239,6 +239,8 @@ switch ($action) {
                     EMAIL_TEXT_STATUS_UPDATED . $order_status_label .
                     EMAIL_TEXT_STATUS_PLEASE_REPLY;
 
+                $html_msg['EMAIL_SALUTATION'] = EMAIL_SALUTATION; 
+                $html_msg['EMAIL_ORDER_UPDATE_MESSAGE'] = defined('EMAIL_ORDER_UPDATE_MESSAGE') ? constant('EMAIL_ORDER_UPDATE_MESSAGE') : '';
                 $html_msg['EMAIL_CUSTOMERS_NAME'] = $check_status->fields['customers_name'];
                 $html_msg['EMAIL_TEXT_ORDER_NUMBER'] = EMAIL_TEXT_ORDER_NUMBER . ' ' . $oID;
                 $html_msg['EMAIL_TEXT_INVOICE_URL']  = '<a href="' . $account_history_info_link .'">' . str_replace(':', '', EMAIL_TEXT_INVOICE_URL) . '</a>';


### PR DESCRIPTION
See forum thread: 
https://www.zen-cart.com/showthread.php?227771-Customer-email-text-format-problems-EMAIL_SALUTATION-EMAIL_ORDER_MESSAGE_UPDATE

When Edit Orders is used to make a status change in 1.5.7, the email template values EMAIL_SALUTATION and EMAIL_ORDER_UPDATE_MESSAGE are not substituted.

To test you need Admin > Configuration > Customer Details > Email Salutation = true. 