### PR TITLE
Update comment handling, integration with TyPT v5.0.0+

### DIFF
--- a/zc_plugins/EditOrders/v5.0.0/admin/edit_orders.php
+++ b/zc_plugins/EditOrders/v5.0.0/admin/edit_orders.php
@@ -138,8 +138,19 @@ switch ($action) {
         if (!empty($updated_order->totals['changes'])) {
         }
 
-        $order_changed_message = TEXT_OSH_CHANGED_VALUES . "\n";
-        $order_changed_message .= '<ol>';
+        if (!empty($updated_order->statuses['changes'])) {
+            // -----
+            // Copy the added comment's variables into $_POST for use during
+            // the status-history record's creation.
+            //
+            $osh_info = $updated_order->statuses['changes'];
+            foreach ($osh_info as $key => $value) {
+                $_POST[$key] = $value;
+            }
+            zen_update_orders_history((int)$oID, $osh_info['message'], null, $osh_info['status'], $osh_info['notify'], $osh_info['notify_comments']);
+        }
+
+        $order_changed_message = '';
         foreach ($changed_values as $title => $changes) {
             if ($title === 'osh_info') {
                 continue;
@@ -154,12 +165,9 @@ switch ($action) {
             }
             $order_changed_message .= '</ol>';
         }
-        $order_changed_message .= '</ol>';
-        zen_update_orders_history((int)$oID, $order_changed_message);
-
-        if (!empty($updated_order->statuses['changes'])) {
-            $osh_info = $updated_order->statuses['changes'];
-            zen_update_orders_history((int)$oID, $osh_info['message'], null, $osh_info['status'], $osh_info['notify'], $osh_info['notify_customer']);
+        if ($order_changed_message !== '') {
+            $order_changed_message = TEXT_OSH_CHANGED_VALUES . "\n<ol>" . $order_changed_message . '</ol>';
+            zen_update_orders_history((int)$oID, $order_changed_message);
         }
 
         unset($_SESSION['eoChanges']);

--- a/zc_plugins/EditOrders/v5.0.0/admin/includes/classes/EoOrderChanges.php
+++ b/zc_plugins/EditOrders/v5.0.0/admin/includes/classes/EoOrderChanges.php
@@ -70,19 +70,32 @@ class EoOrderChanges
                 unset($this->updated->$address_type['changes'][$key]);
             }
         }
-//trigger_error(var_export($this->updated, true));
+
         return count($this->updated->$address_type['changes']);
     }
 
     public function addComment(array $posted_values): void
     {
         $status = (int)$posted_values['status'];
-        $this->updated->statuses['changes'] = [
-            'message' => $posted_values['comments'],
-            'status' => $status,
-            'notify' => (int)$posted_values['notify'],
-            'notify_customer' => isset($posted_values['notify_customer']),
-        ];
+        $this->updated->statuses['changes'] = [];
+        foreach ($posted_values as $key => $value) {
+            switch ($key) {
+                case 'status':
+                    $this->updated->statuses['changes']['status'] = $status;
+                    break;
+                case 'notify':
+                    $this->updated->statuses['changes']['notify'] = (int)$value;
+                    break;
+                case 'comments':
+                    $this->updated->statuses['changes']['message'] = $value;
+                    break;
+                default:
+                    $this->updated->statuses['changes'][$key] = $value;
+                    break;
+            }
+        }
+        $this->updated->statuses['changes']['notify_comments'] = isset($posted_values['notify_comments']);
+
         if ($status !== (int)$this->original->info['orders_status']) {
             $this->updated->info['orders_status'] = $status;
             $this->updated->info['changes']['orders_status'] = ENTRY_STATUS;

--- a/zc_plugins/EditOrders/v5.0.0/catalog/includes/classes/ajax/zcAjaxEditOrdersAdmin.php
+++ b/zc_plugins/EditOrders/v5.0.0/catalog/includes/classes/ajax/zcAjaxEditOrdersAdmin.php
@@ -155,29 +155,49 @@ class zcAjaxEditOrdersAdmin
         $original_order = $_SESSION['eoChanges']->getOriginalOrder();
         $updated_order = $_SESSION['eoChanges']->getUpdatedOrder();
         $changes = $_SESSION['eoChanges']->getChangedValues();
-        
+
         $modal_html = '';
         foreach ($changes as $title => $fields_changed) {
             if ($title === 'osh_info') {
-                $fields_changed = $fields_changed[0]['updated'];
-                switch ($fields_changed['notify']) {
-                    case 0:
-                        $customer_notified = TEXT_NO;
-                        break;
-                    case 1:
-                        $customer_notified = TEXT_YES;
-                        break;
-                    default:
-                        $customer_notified = TEXT_HIDDEN;
-                        break;
+                $additional_inputs = '';
+                foreach ($fields_changed[0]['updated'] as $key => $value) {
+                    if (in_array($key, ['comment_added', 'status', 'notify_comments'])) {
+                        continue;
+                    }
+                    switch ($key) {
+                        case 'notify':
+                            switch ($value) {
+                                case 0:
+                                    $customer_notified = TEXT_NO;
+                                    break;
+                                case 1:
+                                    $customer_notified = TEXT_YES;
+                                    break;
+                                default:
+                                    $customer_notified = TEXT_HIDDEN;
+                                    break;
+                            }
+                            break;
+                        case 'message':
+                            if (!empty($value)) {
+                                $message = '<br><br><code>' . $value . '</code>';
+                            }
+                            break;
+                        default:
+                            if (!empty($value)) {
+                                $additional_inputs .= '<br><br><code>' . $key . '</code>: <code>' . $value . '</code>';
+                            }
+                            break;
+                    }
                 }
+
                 $modal_html .=
                     '<div class="panel panel-default">' .
                         '<div class="panel-heading">' . TEXT_COMMENT_ADDED . '</div>' .
                         '<div class="panel-body">' .
                             '<ul class="list-group my-0">' .
                                 '<li class="list-group-item">' .
-                                    '<strong>' . ENTRY_NOTIFY_CUSTOMER . '</strong> ' . $customer_notified . '<br><br><code>' . $fields_changed['message'] . '</code>' .
+                                    '<strong>' . ENTRY_NOTIFY_CUSTOMER . '</strong> ' . $customer_notified . ($message ?? '') . $additional_inputs .
                                 '</li>' .
                             '</ul>' .
                         '</div>' .


### PR DESCRIPTION
- An empty osh record was being written if the order's status was updated without a comment.
- Correct variable name; it's `notify_comments` not `notify_customer`.
- Simplify osh table display, using the same format as `orders.php` so that TyPT (and others) can watch the same notifications.