### PR TITLE
Prevent MailBeez requests from clearing active EO session

### DIFF
--- a/zc_plugins/EditOrders/v5.0.3/admin/includes/init_includes/init_eo_config.php
+++ b/zc_plugins/EditOrders/v5.0.3/admin/includes/init_includes/init_eo_config.php
@@ -1,9 +1,9 @@
 <?php
 // -----
 // Admin-level initialization script for the Edit Orders plugin for Zen Cart, by lat9.
-// Copyright (C) 2018-2025, Vinos de Frutas Tropicales.
+// Copyright (C) 2018-2026, Vinos de Frutas Tropicales.
 //
-// Last updated: v5.0.0
+// Last updated: v5.0.3
 //
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
@@ -23,17 +23,12 @@ if ($current_page === 'ajax.php' && ($_GET['act'] ?? '') === 'ajaxEditOrdersAdmi
     return;
 }
 
-if ($current_page === 'keepalive.php' || $current_page === 'edit_orders.php') {
+if ($current_page === 'keepalive.php' || $current_page === FILENAME_EDIT_ORDERS . '.php') {
     return;
 }
 
 // Do not let background/login/session-check requests wipe an active Edit Orders session.
-if (isset($_SESSION['eoChanges']) && $current_page === 'login.php') {
-    return;
-}
-
-// Do not let MailBeez admin/background requests wipe an active Edit Orders session.
-if (isset($_SESSION['eoChanges']) && $current_page === 'mailbeez.php') {
+if (isset($_SESSION['eoChanges']) && in_array($current_page, ['login.php', 'mailbeez.php'], true)) {
     return;
 }
 
@@ -64,5 +59,6 @@ unset(
     $_SESSION['payment'],
     $_SESSION['shipping'],
     $_SESSION['shipping_tax_description'],
+    $_SESSION['shipping_tax_amount'],
     $_SESSION['valid_to_checkout'],
 );

--- a/zc_plugins/EditOrders/v5.0.3/admin/includes/init_includes/init_eo_config.php
+++ b/zc_plugins/EditOrders/v5.0.3/admin/includes/init_includes/init_eo_config.php
@@ -16,11 +16,24 @@ global $PHP_SELF;
 // as 'edit_orders' for EO's AJAX processing, so that the associated language
 // constants will be pulled in for EO during its AJAX processing.
 //
-if ($PHP_SELF === 'ajax.php' && ($_GET['act'] ?? '') === 'ajaxEditOrdersAdmin') {
-    $PHP_SELF = 'edit_orders.php';
+$current_page = basename($PHP_SELF ?? '');
+
+if ($current_page === 'ajax.php' && ($_GET['act'] ?? '') === 'ajaxEditOrdersAdmin') {
+    $PHP_SELF = FILENAME_EDIT_ORDERS . '.php';
     return;
 }
-if ($PHP_SELF === 'keepalive.php' || $PHP_SELF === FILENAME_EDIT_ORDERS . '.php') {
+
+if ($current_page === 'keepalive.php' || $current_page === 'edit_orders.php') {
+    return;
+}
+
+// Do not let background/login/session-check requests wipe an active Edit Orders session.
+if (isset($_SESSION['eoChanges']) && $current_page === 'login.php') {
+    return;
+}
+
+// Do not let MailBeez admin/background requests wipe an active Edit Orders session.
+if (isset($_SESSION['eoChanges']) && $current_page === 'mailbeez.php') {
     return;
 }
 


### PR DESCRIPTION
With Mailbeez installed on a zen cart site EO will not allow any editing without this patch. Tested with 3 different zencart sites - all using mailbeez. 

Edit Orders stores active order-change state in $_SESSION['eoChanges'] while an order is being edited.

MailBeez admin/background requests can occur while the Edit Orders page remains open in the same admin session. The EO init cleanup currently treats those requests as leaving Edit Orders and unsets EO session state. Subsequent EO AJAX calls can then fail because $_SESSION['eoChanges'] is missing.

This change normalises $PHP_SELF using basename() and prevents MailBeez admin/background requests from clearing an active Edit Orders session.